### PR TITLE
Fix VMFJsonSchemaGenerator alias helper

### DIFF
--- a/jackson/src/main/java/eu/mihosoft/vmf/jackson/VMFJsonSchemaGenerator.java
+++ b/jackson/src/main/java/eu/mihosoft/vmf/jackson/VMFJsonSchemaGenerator.java
@@ -108,8 +108,10 @@ public class VMFJsonSchemaGenerator {
      * @param typeAliases the type aliases to add
      * @return this module
      */
-    public VMFJsonSchemaGenerator withTypeAliases(Map<String, String> typeAliases) {
-        typeAliases.forEach(this::addTypeAlias);
+    public VMFJsonSchemaGenerator withTypeAliases(Map<String, String> aliases) {
+        if (aliases != null) {
+            aliases.forEach(this::addTypeAlias);
+        }
         return this;
     }
 


### PR DESCRIPTION
## Summary
- avoid NPE in `VMFJsonSchemaGenerator.withTypeAliases`

## Testing
- `./gradlew test --no-daemon -q` *(fails: Execution failed for task ':gradle-plugin:test')*

------
https://chatgpt.com/codex/tasks/task_e_6844871b7e94832ab1d46e4f028de105